### PR TITLE
Implemented screen resolution feature

### DIFF
--- a/app/controllers/server.rb
+++ b/app/controllers/server.rb
@@ -38,10 +38,17 @@ module TrafficSpy
 
       if Payload.new(digest: digest).valid?
          url = Url.find_or_create_by(url: payload_params['url'])
+         resolution = Resolution.find_or_create_by(
+                        resolution_width: payload_params['resolutionWidth'],
+                        resolution_height: payload_params['resolutionHeight'])
          #this is where we add everything else
 
           unless source.nil?
-            payload = Payload.new(digest: digest, source_id: source.id, url_id: url.id)
+            payload = Payload.new(digest: digest,
+                                  source_id: source.id,
+                                  url_id: url.id,
+                                  resolution_id: resolution.id
+            )
             if payload.save
               status 200
               body "OK"
@@ -63,6 +70,8 @@ module TrafficSpy
       @slugs = @slugs.map do |slug|
         slug[0]
       end
+
+      @resolutions = @source.resolutions.uniq
 
       erb :show
     end

--- a/app/models/payload.rb
+++ b/app/models/payload.rb
@@ -1,6 +1,7 @@
 class Payload < ActiveRecord::Base
   belongs_to :source
   belongs_to :url
+  belongs_to :resolution
 
   validates :digest, presence: true, uniqueness: true
 end

--- a/app/models/payload_validator.rb
+++ b/app/models/payload_validator.rb
@@ -1,6 +1,5 @@
  require 'digest'
 
-
  class PayloadValidator
   attr_reader :params,
               :source,

--- a/app/models/resolution.rb
+++ b/app/models/resolution.rb
@@ -1,0 +1,7 @@
+class Resolution < ActiveRecord::Base
+  has_many :payloads
+  has_one :source, through: :payloads
+
+  validates :resolution_width, presence: true, uniqueness: true
+  validates :resolution_height, presence: true, uniqueness: true
+end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -1,3 +1,0 @@
-class Response < ActiveRecord::Base
-  belongs_to :sub_url
-end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,6 +1,7 @@
 class Source < ActiveRecord::Base
   has_many :payloads
   has_many :urls, through: :payloads
+  has_many :resolutions, through: :payloads
 
 
   validates :root_url, presence: true, uniqueness: true

--- a/app/views/show.erb
+++ b/app/views/show.erb
@@ -11,7 +11,14 @@
         <% end %>
       </ul>
       </br>
-      <h4> Most Viewed Urls</h4>
+      <h4>Screen Resolutions</h4>
+      <ul>
+        <% @resolutions.each do |resolution| %>
+          <li><%= resolution.resolution_width %> x <%=
+          resolution.resolution_height %></li>
+        <% end %>
+      </ul>
+      </br>
     </div>
   </div>
 </div>

--- a/db/migrate/20150905201518_create_resolutions.rb
+++ b/db/migrate/20150905201518_create_resolutions.rb
@@ -1,0 +1,10 @@
+class CreateResolutions < ActiveRecord::Migration
+  def change
+    create_table :resolutions do |t|
+      t.string :resolution_height
+      t.string :resolution_width
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150905201724_add_resolution_id_column_to_payloads.rb
+++ b/db/migrate/20150905201724_add_resolution_id_column_to_payloads.rb
@@ -1,0 +1,5 @@
+class AddResolutionIdColumnToPayloads < ActiveRecord::Migration
+  def change
+    add_column :payloads, :resolution_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150903203158) do
+ActiveRecord::Schema.define(version: 20150905201724) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,9 +19,17 @@ ActiveRecord::Schema.define(version: 20150903203158) do
   create_table "payloads", force: :cascade do |t|
     t.integer  "source_id"
     t.string   "digest"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
     t.integer  "url_id"
+    t.integer  "resolution_id"
+  end
+
+  create_table "resolutions", force: :cascade do |t|
+    t.string   "resolution_height"
+    t.string   "resolution_width"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
   end
 
   create_table "sources", force: :cascade do |t|

--- a/test/controllers/process_payload_test.rb
+++ b/test/controllers/process_payload_test.rb
@@ -17,7 +17,7 @@ class ProcessPayloadTest < Minitest::Test
     assert_equal 1, Source.count
     assert_equal 200, last_response.status
 
-    @payload = 'payload={"url":"http://jumpstartlab.com/blog"}'
+    @payload = 'payload={"url":"http://jumpstartlab.com/blog","resolutionWidth":"1920","resolutionHeight":"1280"}'
   end
 
   def test_it_checks_a_payloads_is_processed_correctly
@@ -55,10 +55,12 @@ class ProcessPayloadTest < Minitest::Test
     assert_equal 'Bad Request - Needs a payload', last_response.body
   end
 
-  def test_url_data_is_populated_when_payload_is_saved
+  def test_data_is_populated_when_payload_is_saved
     assert_equal 0, Url.count
+    assert_equal 0, Resolution.count
     post "/sources/jumpstartlab/data", @payload
     assert_equal 1, Url.count
+    assert_equal 1, Resolution.count
     get "/sources/jumpstartlab"
   end
 

--- a/test/models/resolution_test.rb
+++ b/test/models/resolution_test.rb
@@ -1,0 +1,22 @@
+require_relative "../test_helper"
+
+class ResolutionTest < Minitest::Test
+  def setup
+    DatabaseCleaner.start
+  end
+
+  def test_it_has_the_correct_attributes
+    assert_equal 0, Resolution.count
+
+    resolution = Resolution.new(resolution_height: "1920", resolution_width: "1280")
+    resolution.save
+
+    assert_equal 1, Resolution.count
+    assert_equal "1920", Resolution.find(resolution.id).resolution_height
+    assert_equal "1280", Resolution.find(resolution.id).resolution_width
+  end
+
+  def teardown
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
- The source dashboard now displays screen resolution across all payload
  requests.

This change addresses the need by:
- First I created a new table called resolution that would hold onto
  both the screen width and screen height. As a payload is verified a
  resolution column is immediately populated. I also added a model test
  and I changed the controller test we were using so that it would test
  both the url table and the new resolution table.
